### PR TITLE
feat: ButtonShare 컴포넌트 추가

### DIFF
--- a/src/components/containers/ButtonShare/ButtonShare.jsx
+++ b/src/components/containers/ButtonShare/ButtonShare.jsx
@@ -1,0 +1,22 @@
+import linkIcon from 'assets/link-icon.svg';
+import facebookIcon from 'assets/facebook-icon.svg';
+import kakaoIcon from 'assets/kakao-icon.svg';
+import * as Styled from './StyleButtonShare.js';
+
+function ButtonShare() {
+  const shares = [linkIcon, kakaoIcon, facebookIcon];
+
+  return (
+    <Styled.Ul>
+      {shares.map((option) => {
+        return (
+          <li key={option}>
+            <img src={option} />
+          </li>
+        );
+      })}
+    </Styled.Ul>
+  );
+}
+
+export default ButtonShare;

--- a/src/components/containers/ButtonShare/StyleButtonShare.js
+++ b/src/components/containers/ButtonShare/StyleButtonShare.js
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Ul = styled.ul`
+  display: flex;
+  gap: 12px;
+`;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,3 +2,4 @@ export { default as App } from './App';
 export { default as InputFiled } from './common/InputField/InputField';
 export { default as ButtonBox } from './common/ButtonBox/ButtonBox';
 export { default as NavBar } from './containers/NavBar/NavBar';
+export { default as ButtonShare } from './containers/ButtonShare/ButtonShare';

--- a/src/style/StyleGlobal.js
+++ b/src/style/StyleGlobal.js
@@ -29,14 +29,15 @@ export const StyledGlobal = createGlobalStyle`
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    border: 0;
     font-family: "Pretendard";
     word-break: keep-all;
   }
 
   html,
   body {
-    font-size: 62.5%;
     background-color: var(--gray20);
+    font-size: 62.5%;
   }
 
   h1 {
@@ -63,6 +64,10 @@ export const StyledGlobal = createGlobalStyle`
     font-weight: 400;
   }
 
+  ol, ul {
+    list-style: none;
+  }
+
   a {
     color: inherit;
     text-decoration: none;
@@ -74,8 +79,8 @@ export const StyledGlobal = createGlobalStyle`
   }
 
   button {
-    border: none;
     padding: unset;
+    border: none;
     background-color: unset;
     cursor: pointer;
   }


### PR DESCRIPTION
### 작업내용 
- [x] StyleGlobal 스타일 추가 및 정렬 변경
- [x] ButtonShare 컴포넌트 추가

### 스크린샷
<img width="110" alt="ButtonShare 컴포넌트" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/614fab51-5bfe-42db-80cc-b5ed0a919c63">

### 리뷰어에게
공유를 위한 버튼 컴포넌트를 만들었습니다. 같은 유형이 반복되어 ul-li 을 이용했습니다.
추후 공유화면을 띄우는 작업이 필요합니다.