### PR TITLE
feat: PageButton 컴포넌트 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,20 @@
 <html lang="ko">
   <head>
     <meta charset="utf-8" />
+    <!-- Font: Actor -->
     <link rel="icon" href="./profile-image.svg" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Actor&display=swap"
+    />
+    <!-- Font: Pretendard -->
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css"
+    />
     <title>오픈 마인드</title>
   </head>
   <body>

--- a/src/components/common/PageButton/PageButton.jsx
+++ b/src/components/common/PageButton/PageButton.jsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const PageButton = styled.button`
+  width: 4rem;
+  height: 4rem;
+  text-align: center;
+  font-size: 2rem;
+  font-family: Actor;
+  line-height: 125%;
+  color: var(--gray40);
+
+  &:hover {
+    color: var(--gray60);
+  }
+`;
+
+export default PageButton;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,3 +3,4 @@ export { default as InputFiled } from './common/InputField/InputField';
 export { default as ButtonBox } from './common/ButtonBox/ButtonBox';
 export { default as NavBar } from './containers/NavBar/NavBar';
 export { default as ButtonShare } from './containers/ButtonShare/ButtonShare';
+export { default as PageButton } from './common/PageButton/PageButton';


### PR DESCRIPTION
### 작업내용
- [x] Pretendard, Actor 폰트 링크 추가
- [x] PageButton 컴포넌트 생성 - hover시 색상 변경

### 스크린샷
<img width="82" alt="PageButton" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/cae1f681-f643-4df1-af1d-ecd87ea254c9">


### 리뷰어에게
현재는 버튼 태그로 스타일드 컴포넌트로 구현했습니다.
선택했을 경우의 디자인은 추후 구현해야할 것 같습니다.