### PR TITLE
feat: ProfileImage 컴포넌트 추가

### DIFF
--- a/src/components/common/ProfileImage/ProfileImage.jsx
+++ b/src/components/common/ProfileImage/ProfileImage.jsx
@@ -1,0 +1,11 @@
+import * as Styled from './StyleProfileImage';
+
+function ProfileImage({ src, size }) {
+  return (
+    <Styled.Div>
+      <Styled.Img src={src} alt="프로필 이미지" size={size} />
+    </Styled.Div>
+  );
+}
+
+export default ProfileImage;

--- a/src/components/common/ProfileImage/ProfileImage.jsx
+++ b/src/components/common/ProfileImage/ProfileImage.jsx
@@ -1,9 +1,14 @@
 import * as Styled from './StyleProfileImage';
 
-function ProfileImage({ src, size }) {
+function ProfileImage({ src, size, mobileSize }) {
   return (
     <Styled.Div>
-      <Styled.Img src={src} alt="프로필 이미지" size={size} />
+      <Styled.Img
+        src={src}
+        alt="프로필 이미지"
+        size={size}
+        mobileSize={mobileSize}
+      />
     </Styled.Div>
   );
 }

--- a/src/components/common/ProfileImage/StyleProfileImage.js
+++ b/src/components/common/ProfileImage/StyleProfileImage.js
@@ -18,7 +18,7 @@ export const Img = styled.img`
   width: ${({ size }) => (size ? SIZES[size] : SIZES['mediumLarge'])}px;
   height: ${({ size }) => (size ? SIZES[size] : SIZES['mediumLarge'])}px;
 
-  @media (min-width: 375px) and (max-width: 767px) {
+  @media max-width: 767px {
     width: ${({ mobileSize }) =>
       mobileSize ? SIZES[mobileSize] : SIZES['mediumSmall']}px;
     height: 

--- a/src/components/common/ProfileImage/StyleProfileImage.js
+++ b/src/components/common/ProfileImage/StyleProfileImage.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+const SIZES = {
+  xLarge: 136,
+  large: 104,
+  medium: 60,
+  small: 48,
+  xSmall: 28,
+};
+
+export const Div = styled.div`
+  border-radius: 70%;
+  overflow: hidden;
+`;
+
+export const Img = styled.img`
+  width: ${({ size }) => (size ? SIZES[size] : SIZES['medium'])}px;
+  height: ${({ size }) => (size ? SIZES[size] : SIZES['medium'])}px;
+
+  @media (min-width: 375px) and (max-width: 767px) {
+    width: ${({ size }) =>
+      size == 'xLarge' ? SIZES['large'] : SIZES['small']}px;
+    height: ${({ size }) =>
+      size == 'xLarge' ? SIZES['large'] : SIZES['small']}px;
+  }
+`;

--- a/src/components/common/ProfileImage/StyleProfileImage.js
+++ b/src/components/common/ProfileImage/StyleProfileImage.js
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 
 const SIZES = {
-  xLarge: 136,
-  large: 104,
-  medium: 60,
-  small: 48,
+  xLarge: 136, //header
+  large: 104, //header-mobile
+  mediumLarge: 60, //usercard
+  mediumSmall: 48, //usercard-mobile
+  small: 32,
   xSmall: 28,
 };
 
@@ -14,13 +15,13 @@ export const Div = styled.div`
 `;
 
 export const Img = styled.img`
-  width: ${({ size }) => (size ? SIZES[size] : SIZES['medium'])}px;
-  height: ${({ size }) => (size ? SIZES[size] : SIZES['medium'])}px;
+  width: ${({ size }) => (size ? SIZES[size] : SIZES['mediumLarge'])}px;
+  height: ${({ size }) => (size ? SIZES[size] : SIZES['mediumLarge'])}px;
 
   @media (min-width: 375px) and (max-width: 767px) {
-    width: ${({ size }) =>
-      size == 'xLarge' ? SIZES['large'] : SIZES['small']}px;
-    height: ${({ size }) =>
-      size == 'xLarge' ? SIZES['large'] : SIZES['small']}px;
-  }
+    width: ${({ mobileSize }) =>
+      mobileSize ? SIZES[mobileSize] : SIZES['mediumSmall']}px;
+    height: 
+    ${({ mobileSize }) =>
+      mobileSize ? SIZES[mobileSize] : SIZES['mediumSmall']}px;
 `;

--- a/src/components/containers/UserCard/StyleUserCard.js
+++ b/src/components/containers/UserCard/StyleUserCard.js
@@ -32,15 +32,17 @@ export const Container = styled.div`
   }
 `;
 
-export const Img = styled.img`
-  width: 60px;
-  height: 60px;
+// export const Img = styled.img`
+//   width: 60px;
+//   height: 60px;
+//   border-radius: 70%;
+//   overflow: hidden;
 
-  @media (min-width: 375px) and (max-width: 767px) {
-    width: 48px;
-    height: 48px;
-  }
-`;
+//   @media (min-width: 375px) and (max-width: 767px) {
+//     width: 48px;
+//     height: 48px;
+//   }
+// `;
 
 export const Name = styled.p`
   font-family: Actor;

--- a/src/components/containers/UserCard/StyleUserCard.js
+++ b/src/components/containers/UserCard/StyleUserCard.js
@@ -32,18 +32,6 @@ export const Container = styled.div`
   }
 `;
 
-// export const Img = styled.img`
-//   width: 60px;
-//   height: 60px;
-//   border-radius: 70%;
-//   overflow: hidden;
-
-//   @media (min-width: 375px) and (max-width: 767px) {
-//     width: 48px;
-//     height: 48px;
-//   }
-// `;
-
 export const Name = styled.p`
   font-family: Actor;
   font-size: 2rem;

--- a/src/components/containers/UserCard/StyleUserCard.js
+++ b/src/components/containers/UserCard/StyleUserCard.js
@@ -3,13 +3,13 @@ import { ReactComponent as Messages } from 'assets/icon/messages.svg';
 
 /* PC: 1200px 이상
 Tablet: 768px 이상 ~ 1199px 이하
-Mobile: 375px 이상 ~ 767px 이하*/
+Mobile: 767px 이하*/
 
 export const MessageIcon = styled(Messages)`
   width: 18px;
   height: 18px;
 
-  @media (min-width: 375px) and (max-width: 767px) {
+  @media max-width: 767px {
     width: 16px;
     height: 16px;
   }
@@ -27,7 +27,7 @@ export const Container = styled.div`
   border-radius: 16px;
   background: var(--gray10);
 
-  @media (min-width: 375px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     padding: 16px;
   }
 `;
@@ -38,7 +38,7 @@ export const Name = styled.p`
   line-height: 2.5rem%;
   color: var(--gray60);
 
-  @media (min-width: 375px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     font-size: 1.8rem;
     line-height: 2.4rem;
   }
@@ -50,7 +50,7 @@ export const P = styled.p`
   color: var(--gray40);
   white-space: nowrap;
 
-  @media (min-width: 375px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     font-size: 1.4rem;
     line-height: 1.8rem;
   }

--- a/src/components/containers/UserCard/UserCard.jsx
+++ b/src/components/containers/UserCard/UserCard.jsx
@@ -1,10 +1,11 @@
 import * as Styled from './StyleUserCard';
+import { ProfileImage } from 'components';
 
 function UserCard({ src, name, count }) {
   return (
     <Styled.Container>
       <Styled.ProfileContainer>
-        <Styled.Img src={src} alt="프로필 이미지" />
+        <ProfileImage src={src} />
         <Styled.Name>{name}</Styled.Name>
       </Styled.ProfileContainer>
       <Styled.InfoContainer>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,8 @@ export { default as CompleteBadge } from './common/ButtonBadge/CompleteBadge';
 export { default as IncompleteBadge } from './common/ButtonBadge/IncompleteBadge';
 export { default as DropDownList } from './common/DropDownList/DropDownList';
 export { default as ButtonShare } from './common/ButtonShare/ButtonShare';
+export { default as ProfileImage } from './common/ProfileImage/ProfileImage';
 export { default as DropDown } from './containers/DropDown/DropDown';
 export { default as NavBar } from './containers/NavBar/NavBar';
 export { default as UserCard } from './containers/UserCard/UserCard';
+export { default as PostHeader } from './containers/PostHeader/PostHeader';

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -42,8 +42,7 @@ const HomePage = () => {
           <ButtonBox onClick={handleButtonClick}>질문 받기</ButtonBox>
         </Styled.InputBox>
       </Styled.MainContainer>
-      <Styled.TwoGuysImage />
-
+      <Styled.TwoGuysImg />
     </>
   );
 };

--- a/src/pages/StyleHomePage.js
+++ b/src/pages/StyleHomePage.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import logoImg from 'assets/logo.svg';
 
-import twoGuysImage from 'assets/two-guys-image.png';
+import twoGuysImg from 'assets/two-guys-image.png';
 
 export const MainContainer = styled.div`
   display: flex;
@@ -36,7 +36,7 @@ export const InputBox = styled.div`
   background-color: var(--gray10);
 `;
 
-export const TwoGuysImage = styled.div`
+export const TwoGuysImg = styled.div`
   position: absolute;
   bottom: 0;
   left: 50%;
@@ -44,7 +44,7 @@ export const TwoGuysImage = styled.div`
   width: 100vw;
   max-width: 1800px;
   height: 100vh;
-  background-image: url(${twoGuysImage});
+  background-image: url(${twoGuysImg});
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center bottom;


### PR DESCRIPTION
### 작성내용
- [x] ProfileImage 컴포넌트 구현 - src, size, mobileSize를 속성으로 받습니다. size 종류는 6가지 입니다.
    - SIZES[xLarge, large, mediumLarge, mediumSmall, small, xSmaill]
- [x] UserCard에 Image 변수명 Img로 바꿨습니다. (제가 착가해서 Image로 바꾼거,,, 실수복구했습니다ㅠㅠ)
- [x] UserCard에 프로필 이미지 부분 ProfileImage 컴포넌트로 교체했습니다.
- [x] Mobile 사이즈 min-width 제거했습니다.

### 스크린샷
[PC - mediumLarge(60px)]
<img width="114" alt="profile60" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/78c62222-0de4-40da-b7eb-722b093bbaa1">

[Mobile - mediumSmall(48px)]
<img width="112" alt="profile48" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/2c5942d8-556e-4065-8403-9e9efe604f11">


### 리뷰어에게
- 프로필 이미지 따로 컴포넌트로 빼는게 나을 것 같아서 새로 만들었습니다.