### PR TITLE
fix: Post 헤더와 메인 겹침 현상 해결

### DIFF
--- a/src/components/common/Toast/StyleToast.js
+++ b/src/components/common/Toast/StyleToast.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 //'URL이 복사되었습니다' ToastButton으로 사용합니다
-export const ToastButton = styled.button`
+export const Toast = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -13,5 +13,4 @@ export const ToastButton = styled.button`
   line-height: 18px;
   color: var(--gray10);
   box-shadow: var(--shadow-2pt);
-  cursor: default;
 `;

--- a/src/components/common/ToastButton/StyleToastButton.js
+++ b/src/components/common/ToastButton/StyleToastButton.js
@@ -13,4 +13,5 @@ export const ToastButton = styled.button`
   line-height: 18px;
   color: var(--gray10);
   box-shadow: var(--shadow-2pt);
+  cursor: default;
 `;

--- a/src/components/containers/PostHeader/PostHeader.jsx
+++ b/src/components/containers/PostHeader/PostHeader.jsx
@@ -1,6 +1,6 @@
 import { ProfileImage, ButtonShare } from 'components';
 import * as Styled from './StylePostHeader';
-import TwoGuysImg from 'assets/twoguys-image-half.svg';
+
 import LogoImg from 'assets/logo.svg';
 
 function PostHeader({ src, name }) {
@@ -13,7 +13,6 @@ function PostHeader({ src, name }) {
           <Styled.Name>{name}</Styled.Name>
           <ButtonShare name={name} image={src} />
         </Styled.Container>
-        <Styled.Background src={TwoGuysImg} />
       </Styled.Header>
     </>
   );

--- a/src/components/containers/PostHeader/StylePostHeader.js
+++ b/src/components/containers/PostHeader/StylePostHeader.js
@@ -1,15 +1,16 @@
 import styled from 'styled-components';
+import TwoGuysImg from 'assets/twoguys-image-half.svg';
 
 export const Header = styled.div`
-  display: flex;
+  display: block;
   justify-content: center;
-  overflow: hidden;
-`;
+  background-image: url(${TwoGuysImg});
+  background-position: top center;
+  background-size: auto;
+  background-repeat: no-repeat;
 
-export const Background = styled.img`
-  min-width: 1200px;
-  @media (max-width: 767px) {
-    min-width: 906px;
+  @media (max-width: 1199px) {
+    background-size: 1200px;
   }
 `;
 
@@ -18,12 +19,10 @@ export const Container = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   height: auto;
   padding-top: 50px;
+  margin-bottom: 10px;
 `;
 
 export const Logo = styled.img`

--- a/src/pages/StyleFeedPage.js
+++ b/src/pages/StyleFeedPage.js
@@ -6,13 +6,14 @@ export const MainContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-top: 120px;
-  margin-bottom: 120px;
+  margin-bottom: 140px;
 `;
 
 export const ButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
+  position: absolute;
+  top: 0;
   width: 684px;
   margin-bottom: 9px;
 `;
@@ -35,6 +36,7 @@ export const CardContainer = styled.div`
   flex-direction: column;
   gap: 20px;
   width: 684px;
+  margin-top: 54px;
   padding: 16px;
   border: 1px solid var(--brown30);
   border-radius: 16px;


### PR DESCRIPTION
### 작업내용
- [x] ButtonShare 컴포넌트의 링크 버튼과 Toast 컴포넌트 연결 - 떴다가 사라지는 기능은 구현중
- [x] Post 헤더의 absolute 포지션으로 영역 인지 불가 문제 해결
     - PostHeader: div에 background image로 넣어 absolute 속성 없이 구현
     - FreeCard: '삭제하기' 버튼 absolute로 바꿔 버튼 유무와 관계없이 margin-top 유지하도록 변경

### 스크린샷
<img width="600" alt="Screen Shot 2023-11-08 at 15 57 49" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/c4060a13-79ee-40c1-a931-de363aaba78c">

### 리뷰어에게
- 헤더작업이었지만... 브랜치 변경하면 오류날 것 같아 우선 ButtonShare에 담아 Push했습니다!
- 뒤이어 작업하겠습니다~!