### PR TITLE
feat: 링크 복사 후 Toast 5초 보이다 사라지는 기능 구현

### DIFF
--- a/src/components/common/ButtonShare/ButtonShare.jsx
+++ b/src/components/common/ButtonShare/ButtonShare.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import Toast from '../Toast/Toast';
 import * as Styled from './StyleButtonShare.js';
 import * as handle from 'utils/shareSNS.js';
 import linkIcon from 'assets/link-icon.svg';
@@ -5,29 +7,47 @@ import facebookIcon from 'assets/facebook-icon.svg';
 import kakaoIcon from 'assets/kakao-icon.svg';
 
 function ButtonShare({ name, src }) {
+  const [isToastOn, setIsToastOn] = useState(false);
+
   const sharedUrl = window.location.href;
 
+  const handleCopyUrl = (url) => {
+    try {
+      handle.copyUrl(url);
+      setIsToastOn(true);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
   return (
-    <Styled.Ul>
-      <Styled.Img
-        src={linkIcon}
-        onClick={() => {
-          handle.copyUrl(sharedUrl);
-        }}
-      />
-      <Styled.Img
-        src={kakaoIcon}
-        onClick={() => {
-          handle.shareKakao(name, src, sharedUrl);
-        }}
-      />
-      <Styled.Img
-        src={facebookIcon}
-        onClick={() => {
-          handle.shareFacebook(sharedUrl);
-        }}
-      />
-    </Styled.Ul>
+    <>
+      <Styled.Container>
+        <Styled.Ul>
+          <Styled.Img
+            src={linkIcon}
+            onClick={() => {
+              handleCopyUrl(sharedUrl);
+            }}
+          />
+          <Styled.Img
+            src={kakaoIcon}
+            onClick={() => {
+              handle.shareKakao(name, src, sharedUrl);
+            }}
+          />
+          <Styled.Img
+            src={facebookIcon}
+            onClick={() => {
+              handle.shareFacebook(sharedUrl);
+            }}
+          />
+        </Styled.Ul>
+      </Styled.Container>
+      {isToastOn && (
+        <Toast setStatus={setIsToastOn}>URL이 복사되었습니다</Toast>
+      )}
+    </>
   );
 }
 

--- a/src/components/common/ButtonShare/StyleButtonShare.js
+++ b/src/components/common/ButtonShare/StyleButtonShare.js
@@ -1,7 +1,13 @@
 import styled from 'styled-components';
 
+export const Container = styled.div`
+  display: relative;
+`;
+
 export const Ul = styled.ul`
   display: flex;
+  justify-content: center;
+  align-items: center;
   gap: 12px;
 `;
 

--- a/src/components/common/Toast/StyleToast.js
+++ b/src/components/common/Toast/StyleToast.js
@@ -2,9 +2,14 @@ import styled from 'styled-components';
 
 //'URL이 복사되었습니다' ToastButton으로 사용합니다
 export const Toast = styled.div`
+  z-index: 90;
   display: flex;
   justify-content: center;
   align-items: center;
+  position: fixed;
+  bottom: 60px;
+  left: 50%;
+  transform: translateX(-50%);
   padding: 12px 20px;
   border-radius: 8px;
   background-color: var(--gray60);
@@ -13,4 +18,8 @@ export const Toast = styled.div`
   line-height: 18px;
   color: var(--gray10);
   box-shadow: var(--shadow-2pt);
+
+  @media (max-width: 767px) {
+    bottom: 100px;
+  }
 `;

--- a/src/components/common/Toast/StyleToast.js
+++ b/src/components/common/Toast/StyleToast.js
@@ -13,4 +13,5 @@ export const Toast = styled.div`
   line-height: 18px;
   color: var(--gray10);
   box-shadow: var(--shadow-2pt);
+  cursor: default;
 `;

--- a/src/components/common/Toast/StyleToast.js
+++ b/src/components/common/Toast/StyleToast.js
@@ -13,5 +13,4 @@ export const Toast = styled.div`
   line-height: 18px;
   color: var(--gray10);
   box-shadow: var(--shadow-2pt);
-  cursor: default;
 `;

--- a/src/components/common/Toast/Toast.jsx
+++ b/src/components/common/Toast/Toast.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import * as Styled from './StyleToast';
+
+export default function Toast({ setStatus, children }) {
+  useEffect(() => {
+    setTimeout(() => {
+      setStatus(false);
+    }, 5000);
+  }, []);
+
+  return <Styled.Toast>{children}.</Styled.Toast>;
+}


### PR DESCRIPTION
### 작업내용
- [x] 링크 아이콘 클릭시 "URL이 복사되었습니다" Toast 컴포넌트 보이다 5초 후 사라지는 기능

### 스크린샷
<img width="531" alt="Toast" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/7ee00f80-4232-4166-b733-0eb327279422">

### 리뷰어에게
- Toast가 styled-component였는데 일반 컴포넌트로 바꿔주고 setTimeout 함수 이용하여 5초 후 종료되도록 했습니다.