### PR TITLE
feat: PostHeader 컴포넌트에서 subject 정보 받아와서 프로필 적용해주는 기능 구현

### DIFF
--- a/src/components/containers/PostHeader/PostHeader.jsx
+++ b/src/components/containers/PostHeader/PostHeader.jsx
@@ -1,9 +1,29 @@
 import { ProfileImage, ButtonShare } from 'components';
+import { getSubjects } from 'api/api';
 import { Link } from 'react-router-dom';
 import * as Styled from './StylePostHeader';
 import LogoImg from 'assets/logo.svg';
+import { useEffect, useState } from 'react';
 
-function PostHeader({ src, name }) {
+function PostHeader({ id }) {
+  const [subjectName, setSubjectName] = useState('');
+  const [subjectImg, setSubjectImg] = useState('');
+
+  const getSubjectInfo = async (subjectId) => {
+    try {
+      const result = await getSubjects(subjectId);
+      const { name, imageSource } = result;
+      setSubjectName(name);
+      setSubjectImg(imageSource);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    getSubjectInfo(id);
+  }, [id]);
+
   return (
     <>
       <Styled.Header>
@@ -11,9 +31,9 @@ function PostHeader({ src, name }) {
           <Link to={'/'}>
             <Styled.Logo src={LogoImg} />
           </Link>
-          <ProfileImage src={src} size="xLarge" mobilesize="large" />
-          <Styled.Name>{name}</Styled.Name>
-          <ButtonShare name={name} image={src} />
+          <ProfileImage src={subjectImg} size="xLarge" mobilesize="large" />
+          <Styled.Name>{subjectName}</Styled.Name>
+          <ButtonShare name={subjectName} image={subjectImg} />
         </Styled.Container>
       </Styled.Header>
     </>

--- a/src/pages/AnswerFeedPage.jsx
+++ b/src/pages/AnswerFeedPage.jsx
@@ -40,7 +40,7 @@ const AnswerFeedPage = () => {
 
   return (
     <>
-      <PostHeader />
+      <PostHeader id={subjectId} />
       <Styled.MainContainer>
         <Styled.ButtonContainer>
           <Styled.DeleteButton>삭제하기</Styled.DeleteButton>


### PR DESCRIPTION
### 작업내용
- [x] PostHeader 에서 subject 정보 가져오는 함수 저장
    - id 속성 값으로 받아 해당 id에 대한 subject 정보 가져오기
    - 정보로 프로필 이름 및 이미지 변경
- [x] AnswerFeedPage에서 PostHeader로 subjectId 속성값으로 넘겨주도록 코드 삽입

### 스크린샷
<img width="903" alt="PostHeaderProfile" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/bcd42bbe-b031-4cfa-91d9-afdc83406024">

### 리뷰어에게
- try...catch 부분은 아직 건드리지 않았습니다!
- 아직 QuestionFeedPage에서 PostHeader에 Id 내려주는 것은 적용하지 않았습니다. (QuestionFeedPage 자체에 id 가져오는 기능이 없음)