### PR TITLE
fix: Homepage InputField 사파리 호환 문제 해결

### DIFF
--- a/src/components/common/InputField/StyleInputField.js
+++ b/src/components/common/InputField/StyleInputField.js
@@ -26,10 +26,9 @@ export const PersonImg = styled.div`
 `;
 
 export const InputField = styled.input`
+  width: 100%;
   font-size: 1.4rem;
   color: var(--gray60);
-  flex-grow: 1;
-  border: none;
 
   &::placeholder {
     color: var(--gray40);


### PR DESCRIPTION
### 작업내용
- [x] StyleInputField 스타일 변경
    - flex-grow: 1 → width: 100%
    - ~~border: none~~ 제거(중복 스타일)

### 스크린샷
[픽스전]
<img width="622" alt="before" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/d6d94a3e-dc74-451c-b3f2-cbe9236d63f4">

[픽스후]
<img width="622" alt="after" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/005c4997-1f13-4c86-87fa-4b3569ef8889">
