### PR TITLE
feat: 페이지에 따른 pagination 컴포넌트 변화 구현

### DIFF
--- a/src/components/common/PageButton/Pagination.jsx
+++ b/src/components/common/PageButton/Pagination.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import * as Styled from './StylePageButton';
+import getPageArray from './getPageArray';
 
-const Pagination = ({ total, onClick, limit }) => {
+const Pagination = ({ total, onClick, limit, width }) => {
   const location = useLocation();
   const pageNum = location.pathname.split('/')[2];
   const [num, setNum] = useState(+pageNum);
@@ -11,6 +12,9 @@ const Pagination = ({ total, onClick, limit }) => {
   for (let i = 1; i <= TOTAL_PAGE; i++) {
     pageArr.push(i);
   }
+
+  let arrLen = width > 767 ? 7 : 5;
+  let midArr = getPageArray(arrLen, pageArr, pageNum);
 
   const handleButtonClick = (num) => {
     onClick(limit * (num - 1));
@@ -24,7 +28,15 @@ const Pagination = ({ total, onClick, limit }) => {
 
   return (
     <Styled.PaginationBox>
-      {pageArr.map((item, index) => {
+      {midArr[0] !== 1 && (
+        <>
+          <Link to={`/list/${1}`}>
+            <Styled.PageButton>1</Styled.PageButton>
+          </Link>
+          <Styled.PageDot>...</Styled.PageDot>
+        </>
+      )}
+      {midArr.map((item, index) => {
         return (
           <Link to={`/list/${item}`} key={index}>
             <Styled.PageButton
@@ -36,6 +48,14 @@ const Pagination = ({ total, onClick, limit }) => {
           </Link>
         );
       })}
+      {midArr[midArr.length - 1] !== TOTAL_PAGE && (
+        <>
+          <Styled.PageDot>...</Styled.PageDot>
+          <Link to={`/list/${TOTAL_PAGE}`}>
+            <Styled.PageButton>{TOTAL_PAGE}</Styled.PageButton>
+          </Link>
+        </>
+      )}
     </Styled.PaginationBox>
   );
 };

--- a/src/components/common/PageButton/StylePageButton.js
+++ b/src/components/common/PageButton/StylePageButton.js
@@ -21,3 +21,10 @@ export const PageButton = styled.button`
     color: var(--gray60);
   }
 `;
+
+export const PageDot = styled(PageButton)`
+  cursor: unset;
+  &:hover {
+    color: var(--gray40);
+  }
+`;

--- a/src/components/common/PageButton/getPageArray.js
+++ b/src/components/common/PageButton/getPageArray.js
@@ -1,0 +1,30 @@
+//n은 중간배열길이
+//arr은 원본배열
+//pageNum은페이지넘버
+
+export default function getPageArray(n, arr, pagenum) {
+  const sideLength = Math.floor(n / 2);
+  const TOTAL_PAGE = arr[arr.length - 1];
+  let midArr = [];
+
+  //페이지 수가 부족할 때 같을 때
+  if (n >= TOTAL_PAGE) {
+    for (let i = 1; i <= TOTAL_PAGE; i++) {
+      midArr.push(arr[i - 1]);
+    }
+    return midArr;
+  }
+
+  //그 외
+  let fn = +pagenum - sideLength; //첫숫자
+  let ln = +pagenum + sideLength; //끝숫자
+
+  if (fn < 1) fn = 1;
+  if (ln > TOTAL_PAGE) fn = arr[arr.length - n];
+
+  for (let i = fn; i <= fn + (n - 1); i++) {
+    midArr.push(arr[i - 1]);
+  }
+
+  return midArr;
+}

--- a/src/pages/QuestionListPage.jsx
+++ b/src/pages/QuestionListPage.jsx
@@ -85,7 +85,14 @@ const QuestionListPage = () => {
             <DropDown sort={sort} setSort={setSort} />
           </Styled.ListPageHeaderBox>
           <UserCardSection data={subjectData.data} />
-          <Pagination total={total} onClick={setOffset} limit={limit} />
+          {isLoading || (
+            <Pagination
+              total={total}
+              onClick={setOffset}
+              limit={limit}
+              width={browserWidth}
+            />
+          )}
         </Styled.cardSectionContainer>
         {isOpen && (
           <Modal

--- a/src/pages/StyleNotFoundPage.js
+++ b/src/pages/StyleNotFoundPage.js
@@ -9,6 +9,7 @@ export const MainContainer = styled.div`
 `;
 
 export const Nav = styled.div`
+  z-index: 10;
   text-align: center;
   margin-top: 60px;
   width: 100%;


### PR DESCRIPTION
### 작업내용
- [x] pagination 현재 페이지에 따라 형태와 숫자 다르도록 구현
- [x] 모바일/PC에 따른 페이지번호 개수 변동 구현

### 스크린샷
[PC]
<img width="1204" alt="PC-pagination" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/ac144656-6e89-4529-906e-4b37f422e65e">
[Mobile]
<img width="291" alt="Mobile-pagination" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/183682b5-a497-4a3f-add2-907a4eb69af8">

### 리뷰어에게
- undefined 나오는 부분은 해결이 필요합니다
- total array를 만들지 않고 바로 mid array를 만들 수 있도록 해야합니다.