### PR TITLE
fix: Arrow 아이콘 클릭시 DropDownList 열리지 않는 오류 수정

### DIFF
--- a/src/components/containers/DropDown/DropDown.jsx
+++ b/src/components/containers/DropDown/DropDown.jsx
@@ -45,7 +45,15 @@ function DropDown({ sort, setSort }) {
         {isOpen === 'true' ? (
           <ArrowUp width="14" height="14" fill="var(--gray60)" />
         ) : (
-          <ArrowDown width="14" height="14" fill="var(--gray40)" />
+          <ArrowDown
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsOpen('true');
+            }}
+            width="14"
+            height="14"
+            fill="var(--gray40)"
+          />
         )}
       </Styled.Div>
       {isOpen === 'true' && (


### PR DESCRIPTION
### 작업내용
- [x] DropDown 컴포넌트에서 ArrowDown 아이콘 클릭시에는 isOpen state가 true로 바뀌지 않는 오류 해결
    - 예상원인: 부모요소의 onClick 이벤트와 Dom의 요소 클릭이벤트가 동시 발생하여 isOpen이 true로 바뀌었다가 바로 false로 바뀜
    - 해결방법: e.stopPropagation으로 이벤트 전파를 막고, 아이콘 클릭시 setIsOpen(true) 실행되도록 수정