### PR TITLE
refactor: error handling 및 무한스크롤 무한통신 에러 수정

### DIFF
--- a/src/components/common/ButtonShare/ButtonShare.jsx
+++ b/src/components/common/ButtonShare/ButtonShare.jsx
@@ -6,17 +6,38 @@ import linkIcon from 'assets/link-icon.svg';
 import facebookIcon from 'assets/facebook-icon.svg';
 import kakaoIcon from 'assets/kakao-icon.svg';
 
-function ButtonShare({ name, src }) {
+function ButtonShare({ name, image }) {
   const [isToastOn, setIsToastOn] = useState(false);
+  const [toastMessage, setToastMessag] = useState('');
 
   const sharedUrl = window.location.href;
 
-  const handleCopyUrl = (url) => {
+  const handleCopyUrl = async (url) => {
     try {
-      handle.copyUrl(url);
+      await navigator.clipboard.writeText(url);
       setIsToastOn(true);
-    } catch (err) {
-      console.log(err);
+      setToastMessag('URL이 복사되었습니다');
+    } catch {
+      setIsToastOn(true);
+      setToastMessag('URL 복사에 실패했습니다 🥲');
+    }
+  };
+
+  const handleFacebook = (url) => {
+    try {
+      handle.shareFacebook(url);
+    } catch {
+      setIsToastOn(true);
+      setToastMessag('공유에 실패했습니다 🥲');
+    }
+  };
+
+  const handleKakao = (name, image, url) => {
+    try {
+      handle.shareKakao(name, image, url);
+    } catch {
+      setIsToastOn(true);
+      setToastMessag('공유에 실패했습니다 🥲');
     }
   };
 
@@ -33,20 +54,18 @@ function ButtonShare({ name, src }) {
           <Styled.Img
             src={kakaoIcon}
             onClick={() => {
-              handle.shareKakao(name, src, sharedUrl);
+              handleKakao(name, image, sharedUrl);
             }}
           />
           <Styled.Img
             src={facebookIcon}
             onClick={() => {
-              handle.shareFacebook(sharedUrl);
+              handleFacebook(sharedUrl);
             }}
           />
         </Styled.Ul>
       </Styled.Container>
-      {isToastOn && (
-        <Toast setStatus={setIsToastOn}>URL이 복사되었습니다</Toast>
-      )}
+      {isToastOn && <Toast setStatus={setIsToastOn}>{toastMessage}</Toast>}
     </>
   );
 }

--- a/src/components/common/ReactionButton/ParticleButton.jsx
+++ b/src/components/common/ReactionButton/ParticleButton.jsx
@@ -1,0 +1,46 @@
+import * as Styled from './StyleParticleButton';
+import { useEffect } from 'react';
+import snow from 'assets/christmas/snow.png';
+
+export default function ParticleButton() {
+  //정수인 난수 생성(Max79 Min30)
+  let group = [];
+
+  const handleClick = () => {
+    const num = Math.floor(Math.random() * 50) + 30;
+
+    for (let i = 0; i < num; i++) {
+      //크기 난수 (Max8 Min4)
+      const scale = Math.floor(Math.random() * (8 - 4 + 1)) + 4;
+      //위치 난수 (Max149 Min100)
+      const x = Math.floor(Math.random() * (150 + 100)) - 100;
+      const y = Math.floor(Math.random() * (150 + 100)) - 100;
+      //시간 난수 (Max1699ms Min1000ms)
+      const sec = Math.floor(Math.random() * 1700) + 1000;
+      group.push({ scale, sec, x, y });
+    }
+  };
+
+  useEffect(() => {
+    handleClick();
+  }, []);
+
+  return (
+    <>
+      <Styled.BtnContain>
+        <Styled.Btn>Click Me</Styled.Btn>
+        <Styled.BtnParticles>
+          {group.map((shape) => {
+            <Styled.Shape
+              src={snow}
+              scale={shape.scale}
+              sec={shape.sec}
+              x={shape.x}
+              y={shape.y}
+            />;
+          })}
+        </Styled.BtnParticles>
+      </Styled.BtnContain>
+    </>
+  );
+}

--- a/src/components/common/ReactionButton/StyleParticleButton.js
+++ b/src/components/common/ReactionButton/StyleParticleButton.js
@@ -1,0 +1,59 @@
+import { styled } from 'styled-components';
+
+export const Shape = styled.img`
+  z-index: 15;
+  width: 40px;
+  height: 40px;
+
+  position: absolute;
+  top: ${({ x }) => x},
+  left: ${({ y }) => y},
+
+
+  transform: ${({ scale }) => 'scale(0.' + scale + ')'},
+  transition: ${({ sec }) => sec}ms,
+
+  animation: moving 0.5s linear reverse forwards;
+  @keyframes moving {
+    0%{
+      transform: scale(0);
+    }
+    10%{
+      transform: scale(1);
+    }
+    100%{
+      top: 50%;
+      left: 50%;
+    }
+  }
+`;
+
+export const BtnContain = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 100px;
+  background-color: yellow;
+`;
+
+export const Btn = styled.button`
+  height: 30px;
+  border-radius: 4px;
+  text-align: center;
+  z-index: 10;
+  background-color: red;
+`;
+
+export const BtnParticles = styled.div`
+  width: 100px;
+  height: 100px;
+  position: absolute;
+
+  border-radius: 50%;
+  color: #eee;
+  z-index: 5;
+  background-color: green;
+
+  overflow: hidden;
+`;

--- a/src/components/common/Toast/Toast.jsx
+++ b/src/components/common/Toast/Toast.jsx
@@ -8,5 +8,5 @@ export default function Toast({ setStatus, children }) {
     }, 5000);
   }, []);
 
-  return <Styled.Toast>{children}.</Styled.Toast>;
+  return <Styled.Toast>{children}</Styled.Toast>;
 }

--- a/src/pages/AnswerFeedPage.jsx
+++ b/src/pages/AnswerFeedPage.jsx
@@ -15,6 +15,7 @@ const AnswerFeedPage = () => {
   const offset = useRef(0);
   const [isLoading, setIsLoading] = useState(false);
   const [total, setTotal] = useState(null);
+  const [hasNext, setHasNext] = useState(true);
   const [subjectName, setSubjectName] = useState('');
   const [subjectImg, setSubjectImg] = useState('');
   const [questionData, setQuestionData] = useState({
@@ -26,11 +27,12 @@ const AnswerFeedPage = () => {
     setIsLoading(true);
     try {
       const result = await getSubjectsQuestion(id, limit, offset.current);
-      const { count, results: questionData } = result;
+      const { count, next, results: questionData } = result;
       setQuestionData((prevData) => ({
         data: [...prevData.data, ...questionData],
       }));
       setTotal(count);
+      setHasNext(next);
     } catch (err) {
       console.error(err);
       navigate(`/InvalidQuestionSubject`);
@@ -47,12 +49,10 @@ const AnswerFeedPage = () => {
   };
 
   const observeCallback = (entries) => {
-    if (isLoading) return;
-
     entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        handleFeedCardSection(subjectId, LIMIT, offset);
-      }
+      if (isLoading) return;
+      if (!entry.isIntersecting) return;
+      handleFeedCardSection(subjectId, LIMIT, offset);
     });
   };
 
@@ -84,7 +84,7 @@ const AnswerFeedPage = () => {
           setTotal={setTotal}
           setQuestionData={setQuestionData}
         />
-        <Styled.ObserveTargetBox ref={target} />
+        {hasNext && <Styled.ObserveTargetBox ref={target} />}
         {isLoading && <ModalLoading back="noBG" />}
       </Styled.MainContainer>
     </>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -32,7 +32,8 @@ const HomePage = () => {
       result[0].results.map((data) => list.push(data.name));
       setAllList((prevArray) => [...prevArray, list]);
     } catch (error) {
-      console.log(error);
+      console.error(error);
+      navigate(`/FailToLoadData`);
     }
   };
 
@@ -65,8 +66,9 @@ const HomePage = () => {
           navigate(`/post/${userId}/answer`);
         }
       }
-    } catch (err) {
-      console.log(err);
+    } catch (error) {
+      console.error(error);
+      navigate(`/WrongInformation`);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -18,6 +18,10 @@ const NotFoundPage = () => {
       setMessage('Use Your Own Account!');
     } else if (message === 'InvalidQuestionSubject') {
       setMessage('Invalid Question Subject!');
+    } else if (message === 'FailToLoadData') {
+      setMessage('Fail to load data. Try again!');
+    } else if (message === 'WrongInformation') {
+      setMessage('Wrong information. Try again!');
     }
   };
 

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { ThemeContext } from 'styled-components';
 import * as Styled from './StyleNotFoundPage';
 import logo from 'assets/logo.svg';
 
@@ -7,9 +8,10 @@ const NotFoundPage = () => {
   const location = useLocation();
   const whatErrorFrom = location.pathname.split('/')[1];
   const [message, setMessage] = useState('');
-
-  const gifUrl =
-    'https://media.giphy.com/media/3ohs7KViF6rA4aan5u/giphy.gif?cid=ecf05e47xhk2cqh66hl2qlmrhfd23c3s0gt2dbkcxl9y6cdq&ep=v1_gifs_search&rid=giphy.gif&ct=g';
+  const theme = useContext(ThemeContext);
+  const gifUrl = theme.snow
+    ? 'https://media.giphy.com/media/3orifiKw74WT9ADnsQ/giphy.gif'
+    : 'https://media.giphy.com/media/3ohs7KViF6rA4aan5u/giphy.gif?cid=ecf05e47xhk2cqh66hl2qlmrhfd23c3s0gt2dbkcxl9y6cdq&ep=v1_gifs_search&rid=giphy.gif&ct=g';
 
   const handlePrintMessage = (message) => {
     if (message === 'UseYourOwnAccount') {

--- a/src/pages/QuestionFeedPage.jsx
+++ b/src/pages/QuestionFeedPage.jsx
@@ -11,7 +11,7 @@ import useModal from 'hooks/useModal';
 import { getSubjectsQuestion } from 'api/api';
 import * as Styled from './StyleFeedPage';
 
-const LIMIT = 3;
+const LIMIT = 5;
 
 const QuestionFeedPage = () => {
   const location = useLocation();
@@ -20,6 +20,7 @@ const QuestionFeedPage = () => {
   const { isOpen, openModal, closeModal } = useModal();
   const option = { visible: true, filter: true };
   const target = useRef();
+  const [hasNext, setHasNext] = useState(true);
   const offset = useRef(0);
   const [isLoading, setIsLoading] = useState(false);
   const [total, setTotal] = useState(null); //전체 질문 수
@@ -34,11 +35,12 @@ const QuestionFeedPage = () => {
     setIsLoading(true);
     try {
       const result = await getSubjectsQuestion(id, limit, offset.current);
-      const { count, results: questionData } = result;
+      const { count, next, results: questionData } = result;
       setQuestionData((prevData) => ({
         data: [...prevData.data, ...questionData],
       }));
       setTotal(count);
+      setHasNext(next);
     } catch (err) {
       console.log(err);
       navigate(`/InvalidQuestionSubject`);
@@ -80,7 +82,7 @@ const QuestionFeedPage = () => {
           data={questionData.data}
           subjectData={[subjectName, subjectImg]}
         />
-        <Styled.ObserveTargetBox ref={target} />
+        {hasNext && <Styled.ObserveTargetBox ref={target} />}
         {isLoading && <ModalLoading back="noBG" />}
         <Styled.WriteButton onClick={openModal}>
           질문 작성하기

--- a/src/pages/QuestionListPage.jsx
+++ b/src/pages/QuestionListPage.jsx
@@ -45,7 +45,8 @@ const QuestionListPage = () => {
       }));
       setTotal(count);
     } catch (err) {
-      console.log(err);
+      console.error(err);
+      navigate('/FailToLoadData');
     } finally {
       setIsLoading(false);
     }

--- a/src/utils/shareSNS.js
+++ b/src/utils/shareSNS.js
@@ -1,8 +1,3 @@
-//링크 복사
-export const copyUrl = async (sharedUrl) => {
-  await navigator.clipboard.writeText(sharedUrl);
-};
-
 //Facebook
 export const shareFacebook = (sharedUrl) => {
   window.open(


### PR DESCRIPTION
### 작업내용
- [x] 무한스크롤 마지막 데이터 불러온 후 더 이상 데이터 불러오지 않도록 수정
- [x] 무한스크롤 limit 5개로 늘림 (데이터 로딩 안되는 일이 발생하지 않도록)
- [x] console.log(error)를 NotFoundPage 또는 toast로 에러 핸들링
- [x] 크리스마스 테마시 NotFoundPage gif 변경 

### 스크린샷
[무한스크롤]
<img width="300" alt="무한스크롤" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/31898022-18b9-4722-8a64-887a802b9d6c">
 
[에러 > 토스트 메시지 띄우기]
<img width="400" alt="공유실패" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/42a0d1f0-72d4-4b70-9975-de83ccf2f725">

[에러 > NotFoundPage로 이동]
<img width="400" alt="FailToLoadData" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/a2c394e1-86e2-4ba8-9953-868cc893082e">


### 리뷰어에게


