### PR TITLE
feat: 새로고침 후에도 theme 유지하는 기능 추가

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,8 @@ import { StyledGlobal } from 'style/StyleGlobal';
 import THEME from 'style/theme';
 
 const App = () => {
-  const [theme, setTheme] = useState(THEME['basic']);
+  const initTheme = localStorage.getItem('theme');
+  const [theme, setTheme] = useState(THEME[initTheme]);
 
   return (
     <>

--- a/src/components/common/Toggle/Toggle.jsx
+++ b/src/components/common/Toggle/Toggle.jsx
@@ -3,7 +3,9 @@ import THEME from 'style/theme';
 import * as Styled from './StyleToggle';
 
 const Toggle = ({ setTheme }) => {
-  const [isOn, setIsOn] = useState(false);
+  const initTheme =
+    localStorage.getItem('theme') === 'christmas' ? true : false;
+  const [isOn, setIsOn] = useState(initTheme);
 
   const toggleHandler = () => {
     setIsOn(!isOn);
@@ -12,8 +14,10 @@ const Toggle = ({ setTheme }) => {
   useEffect(() => {
     if (isOn) {
       setTheme(THEME['christmas']);
+      localStorage.setItem('theme', 'christmas');
     } else {
       setTheme(THEME['basic']);
+      localStorage.setItem('theme', 'basic');
     }
   }, [isOn]);
 


### PR DESCRIPTION
### 작업내용
- [x] Toggle 클릭시 localStorage에 값 저장
- [x] 새로고침 또는 url 접속시 기존 localStorage 값 불러와 세팅 

### 스크린샷
<img width="790" alt="theme localStorage" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/e078f5c2-57aa-4da7-b18a-43cb7b5fa39a">

### 리뷰어에게
Toggle에서도 getItem으로 LocalStorage 값을 가져오지만,
App에서도 getItem하여 초기값을 세팅해줍니다.
그렇지 않으면 크리스마스 테마가 저장되어 있더라도 basic 테마가 잠시 보였다가 christmas 테마로 변경되더라고요!