### PR TITLE
chore: profile image curserpointer 제한

### DIFF
--- a/src/components/common/ProfileImage/StyleProfileImage.js
+++ b/src/components/common/ProfileImage/StyleProfileImage.js
@@ -16,7 +16,7 @@ export const Container = styled.div`
   overflow: hidden;
   flex-shrink: 0;
   text-align: center;
-  cursor: pointer;
+  cursor: ${({$filter}) => $filter && 'pointer'};
 
   :hover {
     filter: ${({$filter}) => $filter && `brightness(0.5)`};

--- a/src/pages/QuestionFeedPage.jsx
+++ b/src/pages/QuestionFeedPage.jsx
@@ -61,7 +61,7 @@ const QuestionFeedPage = () => {
   };
 
   const observer = new IntersectionObserver(observeCallback, {
-    threshold: 0.4,
+    threshold: 0.2,
   });
 
   useEffect(() => {


### PR DESCRIPTION
- [x] profile image answerFeedPage에서만 curser : pointer사용할 수 있도록 수정했습니다.
- [x] 기존 0.4로 했을때 화면크기에 따라 감지가 안되서 질문을 못받아와서,  threshold : 0.2 로 변경습니다.