### PR TITLE
fix: 테마 토글 일원화하여 모바일에서 상태 반영 오류 해결

### DIFF
--- a/src/components/common/Toggle/StyleToggle.js
+++ b/src/components/common/Toggle/StyleToggle.js
@@ -1,17 +1,11 @@
 import styled from 'styled-components';
 
 export const ToggleContainer = styled.div`
-  position: relative;
-  left: 47%;
+  z-index: 20;
+  position: absolute;
+  top: 46px;
+  left: 67px;
   cursor: pointer;
-  display: ${({ $mobile }) => $mobile === 'mobile' && 'none'};
-
-  @media (max-width: 767px) {
-    display: unset;
-    position: absolute;
-    top: 46px;
-    left: 67px;
-  }
 `;
 
 export const ToggleBox = styled.div`

--- a/src/components/common/Toggle/Toggle.jsx
+++ b/src/components/common/Toggle/Toggle.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import THEME from 'style/theme';
 import * as Styled from './StyleToggle';
 
-const Toggle = ({ setTheme, mobile }) => {
+const Toggle = ({ setTheme }) => {
   const initTheme =
     localStorage.getItem('theme') === 'christmas' ? true : false;
   const [isOn, setIsOn] = useState(initTheme);
@@ -26,7 +26,6 @@ const Toggle = ({ setTheme, mobile }) => {
       <Styled.ToggleContainer
         // 클릭하면 토글이 켜진 상태(isOn)를 boolean 타입으로 변경하는 메소드가 실행
         onClick={toggleHandler}
-        $mobile={mobile}
       >
         {/* 아래에 div 엘리먼트 2개가 있다. 각각의 클래스를 'toggle-container', 'toggle-circle' 로 지정 */}
         {/* Toggle Switch가 ON인 상태일 경우에만 toggle--checked 클래스를 div 엘리먼트 2개에 모두 추가. 조건부 스타일링을 활용*/}

--- a/src/components/containers/NavBar/NavBar.jsx
+++ b/src/components/containers/NavBar/NavBar.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState, useContext } from 'react';
 import { useLocation, Link } from 'react-router-dom';
-import { ButtonBoxWithArrow, Toggle } from 'components';
+import { ButtonBoxWithArrow } from 'components';
 import { ThemeContext } from 'styled-components';
 import logoImg from 'assets/logo.svg';
 import christmasLogoImg from 'assets/christmas-logo.png';
 import * as Styled from './StyleNavBar';
 
-const NavBar = ({ children, onClick, setTheme }) => {
+const NavBar = ({ children, onClick }) => {
   const location = useLocation();
   const [navProp, setNavProp] = useState('');
   const theme = useContext(ThemeContext);
@@ -22,9 +22,7 @@ const NavBar = ({ children, onClick, setTheme }) => {
   return (
     <Styled.NavBarContainer $location={navProp}>
       <Styled.NavBarLogoBox>
-        {location.pathname === '/' ? (
-          <Toggle setTheme={setTheme} />
-        ) : (
+        {location.pathname !== '/' && (
           <Link to={'/'}>
             <Styled.NavBarLogo src={theme.snow ? christmasLogoImg : logoImg} />
           </Link>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -93,7 +93,7 @@ const HomePage = () => {
 
   return (
     <Styled.PageContainer>
-      <Toggle setTheme={setTheme} mobile="mobile" />
+      <Toggle setTheme={setTheme} />
       <NavBar onClick={handleNavClick} setTheme={setTheme}>
         질문하러 가기
       </NavBar>


### PR DESCRIPTION
### 작업내용
- [x] NavBar 토글을 없애고 Homepage 내 직접 삽입한 토글만 남겨두었습니다.

### 스크린샷
[오류] - mobile 토글 style에 현재 상태 반영이 되어있지 않음
<img width="300" alt="토글에러" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/dfd13f34-f173-4637-ad1c-d96f6caff8c4">

[수정 후] - 토글을 하나만 사용하여 상태 유지되도록 픽스
<img width="300" alt="수정후" src="https://github.com/Ssong-Q/OpenMind/assets/144652458/6911ef3a-85ad-401f-83eb-00759de503ba">

### 리뷰어에게
- 아침에 확인해주시고 괜찮다면 Merge 하겠습니다!