### PR TITLE
fix: AnswerPage 아규먼트 수정

### DIFF
--- a/src/pages/AnswerFeedPage.jsx
+++ b/src/pages/AnswerFeedPage.jsx
@@ -26,7 +26,7 @@ const AnswerFeedPage = () => {
   const handleFeedCardSection = async (id, limit, offset) => {
     setIsLoading(true);
     try {
-      const result = await getSubjectsQuestion(id, limit, offset.current);
+      const result = await getSubjectsQuestion(id, limit, offset);
       const { count, next, results: questionData } = result;
       setQuestionData((prevData) => ({
         data: [...prevData.data, ...questionData],


### PR DESCRIPTION
### 주요 내용
- [x] AnswerPage handleFeedCardSection함수에서 getSubjectsQuestion으로 넘겨주는 3번째 인자가 offset.current로 되어있던 것을 수정
```js
const result = await getSubjectsQuestion(id, limit, offset);
```