### PR TITLE
feat: Toast 메시지 사라질 때 fadeout 애니메이션 효과 추가

### DIFF
--- a/src/components/common/Toast/StyleToast.js
+++ b/src/components/common/Toast/StyleToast.js
@@ -1,4 +1,14 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+//서서히 사라지는 애니메이션
+const fadeout = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;
 
 //'URL이 복사되었습니다' ToastButton으로 사용합니다
 export const Toast = styled.div`
@@ -18,6 +28,8 @@ export const Toast = styled.div`
   line-height: 18px;
   color: var(--gray10);
   box-shadow: var(--shadow-2pt);
+  animation: ${fadeout} 1s;
+  animation-delay: 4s;
 
   @media (max-width: 767px) {
     bottom: 100px;


### PR DESCRIPTION
### 작업내용
- [x] fadeout animation 추가
    - 5초 후 사라지는 setTimeout에 맞추어 4초 delay후 1초 간 fadeout 애니메이션이 실행되며 사라지도록 구현했습니다.

### 스크린샷
![toast animation](https://github.com/Ssong-Q/OpenMind/assets/144652458/d6e5a788-119d-4a6a-b4d6-6a9702d60943)
 

### 리뷰어에게
- setTimeout시간에 맞춰 delay를 추는 방식을 택했는데, 혹시 오차가 생겨 깜빡임이 발생하는 등의 오류가 생길 수도 있을 것 같습니다. 잘 작동하기는 하나, 이 방법이 맞는건가 싶기도 해서 멘토님께 여쭤보고 싶습니다.
-  영상 to Gif 사이트로 오른쪽을 이용해봤습니다. https://ezgif.com/